### PR TITLE
Quarto fixes

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -333,12 +333,14 @@
 
   set figure(gap: 1.3em)
 
-  show figure: it => align(center)[
-    #it
-    #if (it.placement == none){
+  // Use show-set for centering so users/Quarto can override for specific figure kinds
+  show figure: set align(center)
+  show figure: it => {
+    it
+    if it.placement == none {
       v(2.6em, weak: true)
     }
-  ]
+  }
 
   show terms: set par(first-line-indent: 0em)
 

--- a/lib.typ
+++ b/lib.typ
@@ -124,20 +124,15 @@
   set figure(numbering: num =>
     numbering("A.1", counter(heading).get().first(), num)
   )
-  set heading( numbering: (..nums) => {
+  // Just return the numbering string - let the show heading rule handle positioning
+  // (Previously this returned place() which broke #ref and caused inconsistent alignment)
+  set heading(numbering: (..nums) => {
       let vals = nums.pos()
       if vals.len() == 1 {
         return str(numbering("A.1", ..vals)) + "."
       }
       else {
-        context{
-          let main-color = main-color-state.at(here())
-          let color = main-color
-          if vals.len() == 4 {
-            color = black
-          }
-          return place(dx:-4.5cm, box(width: 4cm, align(right, text(fill: color)[#numbering("A.1", ..vals)])))
-        }
+        numbering("A.1", ..vals)
       }
     },
   )

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orange-book"
-version = "0.7.0"
+version = "0.7.1"
 compiler = "0.14.0"
 entrypoint = "lib.typ"
 repository = "https://github.com/flavio20002/typst-orange-template"


### PR DESCRIPTION
Hi @flavio20002!

We are going to bundle typst-orange-template in [Quarto](https://quarto.org/) 1.9 via [a Quarto extension](https://github.com/quarto-ext/orange-book).

I ran into a couple of minor problems, so here's a PR. 

1. In Quarto, code listings are a kind of figure which should be left aligned. If you're willing to change your figure alignment to a show-set rule instead of a show-rule function, it will enable customization downstream.
2. I noticed a bug where references to sections in appendices were getting yanked out of the main text and put in the margin. According to the git history, this seems to be an accident of development which was already fixed for regular chapter section headings. The fix also makes the alignment of heading numbers in the margin consistent between chapters and appendices. 

We are currently bundling a forked version but we'd prefer to move to `@preview` when it becomes available. 

(We're relying on some 0.7 features and fixes, so we're kind of forced to use `@local` for now. And we have a new [typst-gather](https://prerelease.quarto.org/docs/advanced/typst/typst-gather.html) system that makes this easy.)

Thanks for creating this beautiful book template!